### PR TITLE
fixed href for stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,400;0,700;0,900;1,400&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="style.css">
     <link rel="icon"
         href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📋</text></svg>">
     <title>To-Do List 2022 with LocalStorage</title>


### PR DESCRIPTION
I removed the "/" in front of style.css from the link to your stylesheet. It was not allowing the CSS stylesheet to be linked, and work on https://archsofia.github.io/ToDoList_JS/ . Now you should be able to see the styles applied on your live site for this app.